### PR TITLE
Add a new item for "Your application" section.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1199,6 +1199,32 @@
                   </ul>
                 </div>
               </li>
+              <li class="seed" style="position: absolute; left: 0px; top: 70px;">
+                <div class="header">
+                  <div class="check">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26">
+                      <g fill="none" fill-rule="evenodd" stroke-width="3" transform="translate(2 2)">
+                        <path stroke="#9012FE" d="M6 11.402l2.874 2.934L16.06 7"></path>
+                      <circle cx="11" cy="11" r="11"></circle>
+                      </g>
+                    </svg>
+                  </div>
+                  <div class="expend-bar">
+                    <p>Never put sensitive strings into a compiled program</p>
+                    <span class="category">Seed</span>
+                  </div>
+                  <div class="btn">
+                    <img src="/images/arrow-bottom.svg" alt="" class="arrow">
+                  </div>
+                </div>
+                <div class="body">
+                  <p>Usually native applications need to access other services, and because of that you may need privileged credentials to access this services. However, it is a common practice to insert these credentials directly into the application believing the program compilation process is enough to protect this data. But in the event of a breach on your server and an attacker likely to have access to these native programs, it may be possible to obtain these credentials thus increasing the level of the attack:</p>
+                  <ul>
+                    <li><a href="http://www.0x09.com.br/2013/10/why-should-not-put-static-strings.html" target="_blank">http://www.0x09.com.br/not-put-static-strings</a></li>
+                  </ul>
+                </div>
+              </li>
+
             </ul>
           </div>
           <div class="scrollspy" id="users">


### PR DESCRIPTION
This new item explains about why we don't put sensitive values into strings in a native program.
The compilation process do not obfuscate any information to us. We need to protect this kind on information by ourselves.